### PR TITLE
Added a plugin system.

### DIFF
--- a/plugins/advancedFormat.js
+++ b/plugins/advancedFormat.js
@@ -1,0 +1,32 @@
+let advFormat
+export default advFormat = {
+  n : "format",
+  m : function(formatStr = 'YYYY-MM-DDTHH:mm:ssZ') {
+    let oldFormat = this.getOld('format')
+    let oldResult = oldFormat(formatStr)
+
+    const suffixes = ['th', 'st', 'nd', 'rd']
+
+    return oldResult.replace(/Q|ddd|X|x|k{1,2}|S/g, (match) => {
+      switch (match) {
+        case 'Q':
+          return Math.ceil((this.$M + 1) / 3)
+        case 'ddd': {
+          const digits = this.$u.padStart(String(this.$D), 2, '0').slice(-2)
+          const ls = parseInt(digits[1], 10)
+          return this.$D + suffixes[digits[0] === '1' || ls > 3 ? 0 : ls]
+        }
+        case 'k':
+          return this.$H === 0 ? 24 : this.$H
+        case 'kk':
+          return this.$u.padStart(String(this.$H === 0 ? 24 : this.$H), 2, '0')
+        case 'X':
+          return Math.floor(this.$d.getTime() / 1000)
+        case 'x':
+          return this.$d.getTime()
+        default: //'S'
+          return this.$u.padStart(String(this.$ms), 3, '0')
+      }
+    })
+  }
+}

--- a/plugins/advancedFormat.js
+++ b/plugins/advancedFormat.js
@@ -11,20 +11,20 @@ export default advFormat = Dayjs => {
         case 'Q':
           return Math.ceil((this.$M + 1) / 3)
         case 'ddd': {
-          const digits = this.$u.padStart(String(this.$D), 2, '0').slice(-2)
+          const digits = this.Utils().padStart(String(this.$D), 2, '0').slice(-2)
           const ls = parseInt(digits[1], 10)
           return this.$D + suffixes[digits[0] === '1' || ls > 3 ? 0 : ls]
         }
         case 'k':
           return this.$H === 0 ? 24 : this.$H
         case 'kk':
-          return this.$u.padStart(String(this.$H === 0 ? 24 : this.$H), 2, '0')
+          return this.Utils().padStart(String(this.$H === 0 ? 24 : this.$H), 2, '0')
         case 'X':
           return Math.floor(this.$d.getTime() / 1000)
         case 'x':
           return this.$d.getTime()
         default: //'S'
-          return this.$u.padStart(String(this.$ms), 3, '0')
+          return this.Utils().padStart(String(this.$ms), 3, '0')
       }
     })
   }

--- a/plugins/advancedFormat.js
+++ b/plugins/advancedFormat.js
@@ -1,9 +1,8 @@
 let advFormat
-export default advFormat = {
-  n : "format",
-  m : function(formatStr = 'YYYY-MM-DDTHH:mm:ssZ') {
-    let oldFormat = this.getOld('format')
-    let oldResult = oldFormat(formatStr)
+export default advFormat = Dayjs => {
+  const oldFormat = Dayjs.prototype.format
+  Dayjs.prototype.format = function(formatStr = 'YYYY-MM-DDTHH:mm:ssZ') {
+    let oldResult = oldFormat.bind(this)(formatStr)
 
     const suffixes = ['th', 'st', 'nd', 'rd']
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,10 +34,6 @@ class Dayjs {
     this.$ms = this.$d.getMilliseconds()
   }
 
-  getOld(fn) {
-    return this.$o[fn].bind(this)
-  }
-
   isValid() {
     return !(this.$d.toString() === 'Invalid Date')
   }

--- a/src/index.js
+++ b/src/index.js
@@ -16,14 +16,13 @@ const parseConfig = (config) => {
 
 class Dayjs {
   constructor(config) {
-    this.$u = Utils
     this.$d = parseConfig(config)
     this.init()
   }
 
   init() {
     this.$zone = this.$d.getTimezoneOffset() / 60
-    this.$zoneStr = this.$u.padStart(String(this.$zone * -1).replace(/^(.)?(\d)/, '$10$200'), 5, '+')
+    this.$zoneStr = Utils.padStart(String(this.$zone * -1).replace(/^(.)?(\d)/, '$10$200'), 5, '+')
     this.$y = this.$d.getFullYear()
     this.$M = this.$d.getMonth()
     this.$D = this.$d.getDate()
@@ -32,6 +31,11 @@ class Dayjs {
     this.$m = this.$d.getMinutes()
     this.$s = this.$d.getSeconds()
     this.$ms = this.$d.getMilliseconds()
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  Utils() {
+    return Utils
   }
 
   isValid() {
@@ -92,7 +96,7 @@ class Dayjs {
   }
 
   startOf(units, isStartOf = true) { // isStartOf -> endOf
-    const unit = this.$u.prettyUnit(units)
+    const unit = Utils.prettyUnit(units)
     const instanceFactory = (d, m, y = this.$y) => {
       const ins = new Dayjs(new Date(y, m, d))
       return isStartOf ? ins : ins.endOf(C.D)
@@ -134,7 +138,7 @@ class Dayjs {
   }
 
   mSet(units, int) {
-    const unit = this.$u.prettyUnit(units)
+    const unit = Utils.prettyUnit(units)
     switch (unit) {
       case C.DATE:
         this.$d.setDate(int)
@@ -165,12 +169,12 @@ class Dayjs {
   }
 
   set(string, int) {
-    if (!this.$u.isNumber(int)) return this
+    if (!Utils.isNumber(int)) return this
     return this.clone().mSet(string, int)
   }
 
   add(number, units) {
-    const unit = (units && units.length === 1) ? units : this.$u.prettyUnit(units)
+    const unit = (units && units.length === 1) ? units : Utils.prettyUnit(units)
     if (['M', C.M].indexOf(unit) > -1) {
       let date = this.set(C.DATE, 1).set(C.M, this.$M + number)
       date = date.set(C.DATE, Math.min(this.$D, date.daysInMonth()))
@@ -220,7 +224,7 @@ class Dayjs {
         case 'M':
           return String(this.$M + 1)
         case 'MM':
-          return this.$u.padStart(String(this.$M + 1), 2, '0')
+          return Utils.padStart(String(this.$M + 1), 2, '0')
         case 'MMM':
           return months[this.$M].slice(0, 3)
         case 'MMMM':
@@ -228,7 +232,7 @@ class Dayjs {
         case 'D':
           return String(this.$D)
         case 'DD':
-          return this.$u.padStart(String(this.$D), 2, '0')
+          return Utils.padStart(String(this.$D), 2, '0')
         case 'd':
           return String(this.$W)
         case 'dddd':
@@ -236,15 +240,15 @@ class Dayjs {
         case 'H':
           return String(this.$H)
         case 'HH':
-          return this.$u.padStart(String(this.$H), 2, '0')
+          return Utils.padStart(String(this.$H), 2, '0')
         case 'm':
           return String(this.$m)
         case 'mm':
-          return this.$u.padStart(String(this.$m), 2, '0')
+          return Utils.padStart(String(this.$m), 2, '0')
         case 's':
           return String(this.$s)
         case 'ss':
-          return this.$u.padStart(String(this.$s), 2, '0')
+          return Utils.padStart(String(this.$s), 2, '0')
         case 'Z':
           return `${this.$zoneStr.slice(0, -2)}:00`
         case 'ZZ':
@@ -256,10 +260,10 @@ class Dayjs {
   }
 
   diff(input, units, float = false) {
-    const unit = this.$u.prettyUnit(units)
+    const unit = Utils.prettyUnit(units)
     const that = input instanceof Dayjs ? input : new Dayjs(input)
     const diff = this - that
-    let result = this.$u.monthDiff(this, that)
+    let result = Utils.monthDiff(this, that)
     switch (unit) {
       case C.Y:
         result /= 12
@@ -281,7 +285,7 @@ class Dayjs {
       default: // milliseconds
         result = diff
     }
-    return float ? result : this.$u.absFloor(result)
+    return float ? result : Utils.absFloor(result)
   }
 
   daysInMonth() {

--- a/src/index.js
+++ b/src/index.js
@@ -339,12 +339,30 @@ class Dayjs {
 
 
 const dayjs = config => new Dayjs(config)
+const applyExtend = (proto, factory) => {
+  factory.extend = (plugin, isNew = false) => { // eslint-disable-line no-param-reassign
+    // Return a new subclass instead of the original
+    if (isNew) {
+      // Extend the class
+      class PluginDayjs extends proto {}
 
-dayjs.extend = (plugin) => {
-  const proto = Dayjs.prototype
-  proto.$o = proto.$o || {}
-  proto.$o[plugin.n] = proto[plugin.n]
-  proto[plugin.n] = plugin.m
+      // Apply the plugin
+      plugin(PluginDayjs)
+
+      // Make a new factory
+      const pluginFactory = config => new PluginDayjs(config)
+
+      // Apply this method, so the subclass can have more plugins
+      applyExtend(PluginDayjs, pluginFactory)
+      return pluginFactory
+    }
+
+    // Apply the plugin
+    plugin(Dayjs)
+    // Return the factory so it can be chained
+    return factory
+  }
 }
+applyExtend(Dayjs, dayjs)
 
 export default dayjs

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -46,10 +46,11 @@ it('Format Minute m mm', () => {
   expect(dayjs().format('mm')).toBe(moment().format('mm'))
 })
 
-it('Format Second s sss', () => {
+it('Format Second s ss', () => {
   expect(dayjs().format('s')).toBe(moment().format('s'))
   expect(dayjs().format('ss')).toBe(moment().format('ss'))
 })
+
 
 it('Format Time Zone ZZ', () => {
   expect(dayjs().format('Z')).toBe(moment().format('Z'))

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,0 +1,36 @@
+import moment from 'moment'
+import MockDate from 'mockdate'
+import dayjs from '../src'
+import advFormat from '../plugins/advancedFormat'
+
+dayjs.extend(advFormat)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Format Quarter Q', () => {
+  expect(dayjs().format('Q')).toBe(moment().format('Q'))
+})
+
+it('Format Timestamp X x', () => {
+  expect(dayjs().format('X')).toBe(moment().format('X'))
+  expect(dayjs().format('x')).toBe(moment().format('x'))
+})
+
+it('Format Day of Month ddd 1 - 31', () => {
+  expect(dayjs().format('ddd')).toBe(moment().format('Do'))
+})
+
+it('Format Hour k kk 24-hour 1 - 24', () => {
+  expect(dayjs().format('k')).toBe(moment().format('k'))
+  expect(dayjs().format('kk')).toBe(moment().format('kk'))
+})
+
+it('Format Second S', () => {
+  expect(dayjs().format('S')).toBe(moment().format('SSS'))
+})

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -4,6 +4,7 @@ import dayjs from '../src'
 import advFormat from '../plugins/advancedFormat'
 
 dayjs.extend(advFormat)
+const extendedDayjs = dayjs.extend(advFormat, true)
 
 beforeEach(() => {
   MockDate.set(new Date())
@@ -15,22 +16,33 @@ afterEach(() => {
 
 it('Format Quarter Q', () => {
   expect(dayjs().format('Q')).toBe(moment().format('Q'))
+  expect(extendedDayjs().format('Q')).toBe(dayjs().format('Q'))
 })
 
 it('Format Timestamp X x', () => {
   expect(dayjs().format('X')).toBe(moment().format('X'))
   expect(dayjs().format('x')).toBe(moment().format('x'))
+
+  expect(extendedDayjs().format('X')).toBe(dayjs().format('X'))
+  expect(extendedDayjs().format('x')).toBe(dayjs().format('x'))
 })
 
 it('Format Day of Month ddd 1 - 31', () => {
   expect(dayjs().format('ddd')).toBe(moment().format('Do'))
+
+  expect(extendedDayjs().format('ddd')).toBe(dayjs().format('ddd'))
 })
 
 it('Format Hour k kk 24-hour 1 - 24', () => {
   expect(dayjs().format('k')).toBe(moment().format('k'))
   expect(dayjs().format('kk')).toBe(moment().format('kk'))
+
+  expect(extendedDayjs().format('k')).toBe(dayjs().format('k'))
+  expect(extendedDayjs().format('kk')).toBe(dayjs().format('kk'))
 })
 
 it('Format Second S', () => {
   expect(dayjs().format('S')).toBe(moment().format('SSS'))
+
+  expect(extendedDayjs().format('S')).toBe(dayjs().format('S'))
 })


### PR DESCRIPTION
The plugin system allows users to extend dayjs with additional plugins,
or change existing functionality.

The plugins work by calling the extend method:

```
dayjs.extend({
  n: "methodName",
  m: function(arguments) {
     //
  }
})
```

When overwriting a function, the original function can be referenced from
inside the plugin using:

```this.getOld(pluginName)```

For example:

```
dayjs.extend({
  n: "format",
  m: function(formatStr) {
    let oldFormat = this.getOld("format")
    let oldResults = oldFormat(formatStr)
    ...
})
```

This commit also introduces a plugin which extends the format options to include:
-Q: Quarter of the year
-k/kk: 1-24 hour time
-ddd: Date of the month with ordinal (1st-31st)
-S: Milliseconds