### PR TITLE
chore: add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dayjs",
-  "version": "0.0.0-development",
+  "version": "1.5.19",
   "description": "",
   "main": "dist/dayjs.min.js",
   "scripts": {


### PR DESCRIPTION
The version in the package is meant for npm and should be set in general to prevent specific cases where this could be problematic.