### PR TITLE
Fix #105

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ class Dayjs {
   }
 
   init() {
-    this.$zone = this.$d.getTimezoneOffset() / 60
+    this.$zone = this.$d.getTimezoneOffset()
     this.$zoneStr = Utils.padZoneStr(this.$zone)
     this.$y = this.$d.getFullYear()
     this.$M = this.$d.getMonth()
@@ -257,9 +257,9 @@ class Dayjs {
         case 'ss':
           return Utils.padStart(this.$s, 2, '0')
         case 'Z':
-          return `${this.$zoneStr.slice(0, -2)}:00`
-        default: // 'ZZ'
           return this.$zoneStr
+        default: // 'ZZ'
+          return this.$zoneStr.replace(':', '')
       }
     })
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,15 +4,13 @@ export const padStart = (string, length, pad) => {
   return `${Array((length + 1) - s.length).join(pad)}${string}`
 }
 
-export const padZoneStr = (negHour) => {
-  const hour = negHour * -1
-  let replacer = ''
-  if (hour > -10 && hour < 10) {
-    replacer = '$10$200'
-  } else {
-    replacer = '$1$200'
-  }
-  return padStart(String(hour).replace(/^(.)?(\d)/, replacer), 5, '+')
+export const padZoneStr = (negMinuts) => {
+  const minutes = Math.abs(negMinuts)
+  const sign = negMinuts <= 0 ? '+' : '-'
+  const hourOffset = Math.floor(minutes / 60)
+  const minuteOffset = minutes % 60
+
+  return `${sign}${padStart(hourOffset, 2, '0')}:${padStart(minuteOffset, 2, '0')}`
 }
 
 export const isNumber = n => (!Number.isNaN(parseFloat(n)) && Number.isFinite(n))

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -14,11 +14,12 @@ it('PrettyUnit', () => {
 })
 
 it('PadZoneStr', () => {
-  expect(padZoneStr('+0')).toBe('+0000')
-  expect(padZoneStr('+1')).toBe('-0100')
-  expect(padZoneStr('-1')).toBe('+0100')
-  expect(padZoneStr('-10')).toBe('+1000')
-  expect(padZoneStr('+10')).toBe('-1000')
+  expect(padZoneStr(0)).toBe('+00:00')
+  expect(padZoneStr(1 * 60)).toBe('-01:00')
+  expect(padZoneStr(-1 * 60)).toBe('+01:00')
+  expect(padZoneStr(-10 * 60)).toBe('+10:00')
+  expect(padZoneStr(10 * 60)).toBe('-10:00')
+  expect(padZoneStr((-5 * 60) - 30)).toBe('+05:30')
 })
 
 it('PadStart', () => {


### PR DESCRIPTION
padZoneStr function from utils.js file was been rewritten
to support timezones with non-zero minutes. GMT +5:30 for example.