### PR TITLE
Add Hour and Minute to diff()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -286,6 +286,12 @@ class Dayjs {
       case C.D:
         result = diff / C.MILLISECONDS_A_DAY
         break
+      case C.H:
+        result = diff / C.MILLISECONDS_A_HOUR
+        break
+      case C.MIN:
+        result = diff / C.MILLISECONDS_A_MINUTE
+        break
       case C.S:
         result = diff / C.MILLISECONDS_A_SECOND
         break

--- a/test/display.test.js
+++ b/test/display.test.js
@@ -121,14 +121,14 @@ describe('Difference', () => {
     expect(dayjsA.diff(dayjsB)).toBe(momentA.diff(momentB))
   })
 
-  it('diff -> in seconds, days, weeks, months, quarters, years ', () => {
+  it('diff -> in seconds, minutes, hours, days, weeks, months, quarters, years ', () => {
     const dayjsA = dayjs()
     const dayjsB = dayjs().add(1000, 'days')
     const dayjsC = dayjs().subtract(1000, 'days')
     const momentA = moment()
     const momentB = moment().add(1000, 'days')
     const momentC = moment().subtract(1000, 'days')
-    const units = ['seconds', 'days', 'weeks', 'months', 'quarters', 'years']
+    const units = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'quarters', 'years']
     units.forEach((unit) => {
       expect(dayjsA.diff(dayjsB, unit)).toBe(momentA.diff(momentB, unit))
       expect(dayjsA.diff(dayjsB, unit, true)).toBe(momentA.diff(momentB, unit, true))


### PR DESCRIPTION
This PR adds the ability to get the `diff()` of hours and minutes in addition to the types already available.

I added the two units to the test file, but this test was failing for me on master locally, so I didn't investigate too deeply as to the cause. 

Feel free to reach out if you have any concerns with this PR.