### PR TITLE
Update typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,9 +70,9 @@ declare class Dayjs {
 
   isBefore(dayjs: Dayjs): boolean
 
-  isSame(dayjs: Dayjs)
+  isSame(dayjs: Dayjs): boolean
 
-  isAfter(dayjs: Dayjs)
+  isAfter(dayjs: Dayjs): boolean
 
   isLeapYear(): boolean
 }


### PR DESCRIPTION
The compiler was complaining:

xxx/node_modules/dayjs/index.d.ts(73,3): error TS7010: 'isSame', which lacks return-type annotation, implicitly has an 'any' return type.
xxx/node_modules/dayjs/index.d.ts(75,3): error TS7010: 'isAfter', which lacks return-type annotation, implicitly has an 'any' return type.